### PR TITLE
[Feature] Adding usePrevious

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ See `./packages/*` for individual package installation details.
 | [@hooks/interval](packages/interval) | ![npm](https://img.shields.io/npm/v/@hooks/interval?style=flat-square) | React hook to wrap setInterval |,
 | [@hooks/media-query](packages/media-query) | ![npm](https://img.shields.io/npm/v/@hooks/media-query?style=flat-square) | React hook to respond to media queries |,
 | [@hooks/network-status](packages/network-status) | ![npm](https://img.shields.io/npm/v/@hooks/network-status?style=flat-square) | React hook return network status details |,
+| [@hooks/previous](packages/previous) | ![npm](https://img.shields.io/npm/v/@hooks/previous?style=flat-square) | React hook to capture and remember values between renders |,
 | [@hooks/queue](packages/queue) | ![npm](https://img.shields.io/npm/v/@hooks/queue?style=flat-square) | React hook to manage a queue |,
 | [@hooks/raf](packages/raf) | ![npm](https://img.shields.io/npm/v/@hooks/raf?style=flat-square) | React hook to wrap requestAnimationFrame |,
 | [@hooks/render-count](packages/render-count) | ![npm](https://img.shields.io/npm/v/@hooks/render-count?style=flat-square) | React hook to record the render count |,

--- a/packages/previous/README.md
+++ b/packages/previous/README.md
@@ -1,0 +1,31 @@
+# @hooks/previous
+
+React hook to remember a value between renders
+
+![NPM version](https://img.shields.io/npm/v/@hooks/previous?style=flat-square)
+![Travis](https://img.shields.io/travis/com/simmo/hooks?style=flat-square)
+![License](https://img.shields.io/npm/l/@hooks/previous?style=flat-square)
+
+## Install
+
+```bash
+npm i @hooks/previous
+```
+
+## Usage
+
+### usePrevious
+
+```ts
+usePrevious(value: T): T
+```
+
+#### Parameters
+
+##### `value: T`
+
+The value to be returned on the next render.
+
+#### Return
+
+Returns the last value, undefined for initial render.

--- a/packages/previous/client.test.ts
+++ b/packages/previous/client.test.ts
@@ -1,0 +1,21 @@
+import { renderHook } from '@testing-library/react-hooks'
+import usePrevious from '.'
+
+describe('usePrevious', () => {
+  test('returns value from last render', () => {
+    const initialValue = 'a'
+    const { rerender, result } = renderHook(({ value }) => usePrevious(value), {
+      initialProps: { value: initialValue },
+    })
+
+    expect(result.current).toBeUndefined()
+
+    rerender({ value: 'b' })
+
+    expect(result.current).toBe('a')
+
+    rerender({ value: 'c' })
+
+    expect(result.current).toBe('b')
+  })
+})

--- a/packages/previous/index.ts
+++ b/packages/previous/index.ts
@@ -1,0 +1,15 @@
+import { useEffect, useRef } from 'react'
+
+/**
+ * @param value The value to be returned on the next render.
+ * @returns Returns the last value, undefined for initial render.
+ */
+export default function usePrevious<T>(value: T): T {
+  const ref = useRef<T>()
+
+  useEffect(() => {
+    ref.current = value
+  })
+
+  return ref.current
+}

--- a/packages/previous/package.json
+++ b/packages/previous/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@hooks/previous",
+  "description": "React hook to remember a value between renders",
+  "keywords": [
+    "react",
+    "hooks",
+    "usePrevious",
+    "previous"
+  ],
+  "version": "0.0.0",
+  "main": "cjs/index.js",
+  "module": "esm/index.js",
+  "types": "typings/index.d.ts",
+  "typings": "typings/index.d.ts",
+  "files": [
+    "cjs",
+    "esm",
+    "typings"
+  ],
+  "author": "Mike Simmonds (https://mike.id)",
+  "license": "MIT",
+  "scripts": {
+    "prepublishOnly": "yarn build",
+    "build": "node ../../scripts/build",
+    "docs": "node ../../scripts/generateProjectReadme",
+    "tsdoc": "typedoc --json ./docs.json --exclude *.test.ts ./",
+    "read": "node ./read"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "peerDependencies": {
+    "react": ">=16.8"
+  },
+  "devDependencies": {
+    "react": "^16.12.0"
+  }
+}

--- a/packages/previous/server.test.ts
+++ b/packages/previous/server.test.ts
@@ -1,0 +1,14 @@
+/**
+ * @jest-environment node
+ */
+
+import renderHookServer from '../../utils/renderHookServer'
+import usePrevious from '.'
+
+describe('usePrevious', () => {
+  test('returns undefined', () => {
+    const result = renderHookServer(() => usePrevious('test'))
+
+    expect(result).toBeUndefined()
+  })
+})

--- a/packages/previous/tsconfig.json
+++ b/packages/previous/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./"
+  }
+}


### PR DESCRIPTION
Adds `usePrevious`.

Mentioned in https://reactjs.org/docs/hooks-faq.html#how-to-get-the-previous-props-or-state